### PR TITLE
Whitespace tweak

### DIFF
--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -254,17 +254,7 @@ p.excerpt-warning {
  * Same styling is used on the "Browse" page
  */
 ul.atom-post-list {
-  li .atom-post-list-entry {
-    display: flex;
-    flex-direction: row;
-    // Align dates to the right:
-    // justify-content: space-between;
-    flex-wrap: wrap;
-    align-items: baseline;
-
-    a,
-    span {
-      display: block;
-    }
+  li .atom-post-list-entry span {
+    white-space: nowrap;
   }
 }

--- a/browse.markdown
+++ b/browse.markdown
@@ -16,10 +16,7 @@ All posts by date:
     {%- endif -%}
     <li>
       <div class="atom-post-list-entry">
-        <a target="_blank" href="{{ post.url | relative_url }}">
-          {{ post.title | escape }}
-        </a>
-        &nbsp;
+        <a target="_blank" href="{{ post.url | relative_url }}">{{ post.title | escape }}</a>
         <span class="post-meta">
           {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
           ({{ post.date | date: date_format }})

--- a/feed.xsl
+++ b/feed.xsl
@@ -75,10 +75,7 @@
           <xsl:attribute name="href">
             <xsl:value-of select="atom:id" />
           </xsl:attribute>
-          <xsl:value-of select="atom:title" />
-        </a>
-        <!-- &nbsp; -->
-        &#160;
+          <xsl:value-of select="atom:title" /></a>
         <span class="post-meta"> (<xsl:value-of select="atom:updated-readable" />)</span>
         <!--
           Uncomment below to incorporate post excerpts into the styled preview.


### PR DESCRIPTION
In the Atom post feed and Browse section, remove the line break after the post title so that the link underline doesn't extend over the blank. This fix obviates the need for the flex layout given in `_sass/minima/_layout.scss`.