### PR TITLE
Fix sass warnings about deprecated color and math functions

### DIFF
--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @charset "utf-8";
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@100..900&family=Rubik:ital,wght@0,300..900;1,300..900&display=swap');
 
@@ -38,12 +39,12 @@ $spacing-unit: 30px;
 
 $text-color: #111;
 $background-color: #ffffeb;
-$highlight-color: lighten($background-color, 2%);
+$highlight-color: color.adjust($background-color, $lightness: 2%);
 $brand-color: #008000;
 
 $grey-color: #778899;
 $green-color-light: #b7ccb7;
-$grey-color-dark: darken($grey-color, 25%);
+$grey-color-dark: color.adjust($grey-color, $lightness: -25%);
 
 $table-text-align: left;
 

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @use 'sass:math';
 
 /**
@@ -168,7 +169,7 @@ a {
   @include subtle-underline;
 
   &:visited {
-    color: desaturate($brand-color, 50%);
+    color: color.adjust($brand-color, $saturation: -50%);
   }
 
   &:hover {
@@ -340,7 +341,7 @@ table {
   }
 
   th {
-    background-color: lighten($green-color-light, 10%);
+    background-color: color.adjust($green-color-light, $lightness: 10%);
     font-weight: $base-font-strong-weight;
     border-bottom-width: 2px;
   }


### PR DESCRIPTION
Replace deprecated Sass color functions like `lighten()` with `color.adjust()` equivalents. This doesn't suppress all the warnings because some of them come from the vendored minima files.