### PR TITLE
Fonts overhaul: IBM Plex family

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
 
   <title>
     {%- if page.title -%}
@@ -11,13 +12,11 @@
     {%- endif -%}
   </title>
 
-  {%- include easter_egg.html -%}
-
   {%- if page.katex -%}
     {%- include katex.html -%}
   {%- endif -%}
 
-  <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  {%- include easter_egg.html -%}
 
   {%- seo -%}
   {%- feed_meta -%}

--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -1,17 +1,17 @@
 @use "sass:color";
 @charset "utf-8";
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@100..900&family=Rubik:ital,wght@0,300..900;1,300..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&family=IBM+Plex+Sans+KR&family=IBM+Plex+Sans:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap');
 
-$base-font-family: "Rubik", sans-serif;
+$base-font-family: "IBM Plex Sans", "IBM Plex Sans KR", sans-serif;
 $base-font-size: 1rem;
 $base-font-weight: 400;
-// Default bold weight (700) is too intense in Rubik
-$base-font-strong-weight: 450;
+// Default bold weight (700) is too intense
+$base-font-strong-weight: 500;
 $base-line-height: 1.5;
 
-$monospace-font-family: "Noto Sans Mono", monospace;
+$monospace-font-family: "IBM Plex Mono", monospace;
 $monospace-font-size: $base-font-size * 0.9;
-$monospace-font-strong-weight: 600;
+$monospace-font-strong-weight: 500;
 
 @mixin monospace-strong {
   font-family: $monospace-font-family;


### PR DESCRIPTION
Replace the Rubik+Noto Sans Mono fonts with IBM Plex family. I've come to prefer IBM Plex Sans over Rubik because the latter has weirdly long em dashes. Using IBM Plex Mono for the monospace provides greater coherence. I also added IBM Plex Sans KR for Korean text instead of falling back on the user's default CJK font.