### PR TITLE
Workflow tweaks

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           activate-environment: ""
           auto-activate-base: true
-          channels: conda-forge,defaults
+          channels: conda-forge
           channel-priority: true
           mamba-version: "*"
 

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -16,14 +16,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Miniconda and Mamba
+      - name: Set up Miniforge and Mamba
         uses: conda-incubator/setup-miniconda@v3
         with:
           activate-environment: ""
           auto-activate-base: true
           channels: conda-forge
-          channel-priority: true
           mamba-version: "*"
+          miniforge-version: "latest"
 
       - name: Configure toolchain (configure.sh)
         shell: bash -el {0}


### PR DESCRIPTION
Use miniforge instead of miniconda, and only enable the `conda-forge` channel (no `defaults`) to better match how I configure my workstations.