### PR TITLE
Use GH Action to deploy output `_site/` instead of gh-pages branch

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,5 +1,4 @@
-# Based on
-# https://www.moncefbelyamani.com/making-github-pages-work-with-latest-jekyll/
+# Based on https://github.com/actions/upload-pages-artifact
 
 name: build-deploy
 
@@ -11,7 +10,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,13 +40,20 @@ jobs:
         shell: bash -el {0}
         run: ./check.sh
 
-      - name: Deploy GitHub pages site
-        uses: peaceiris/actions-gh-pages@v4
-        # Skip this step if running from somewhere other than master
-        if: github.ref == 'refs/heads/master'
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./_site
-          # if the repo you are deploying to is <username>.github.io, uncomment the line below.
-          # if you are including the line below, make sure your source files are NOT in the "main" branch:
-          publish_branch: gh-pages
+          path: _site/
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This now the recommended approach and it removes the 3rd-party dependency peaceiris/actions-gh-pages action.