### PR TITLE
Add `unzip=6.0.*` as a conda dependency

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -31,6 +31,7 @@ function configure_conda_environment () {
         "make=4.*"
         "ruby=3.3.*"
         "shellcheck=0.10.*"
+        "unzip=6.0.*"
     )
 
     # Location of the conda environment


### PR DESCRIPTION
For portability. This package isn't installed by default on some server distributions, e.g. AlmaLinux.