### PR TITLE
Improve and customize syntax highlighting

### DIFF
--- a/_posts/1970-01-01-formats-masterpost.md
+++ b/_posts/1970-01-01-formats-masterpost.md
@@ -102,6 +102,52 @@ Example below.
 
 ![A screengrab of the terminal output produced by fzl.fish. It shows a list of filenames corresponding to posts on this blog; the post title "Thesis defense" is highlighted.](/assets/images/fish-fzl-example.png)
 
+## Python example
+
+<https://github.com/maxkapur/cronjobs/blob/main/backup_nextcloud_contacts.py>
+
+```python
+def get_connection_parameters():
+    parser = ArgumentParser(
+        description="Create backups of Nextcloud calendar and contacts files"
+    )
+    parser.add_argument(
+        "url", help="Nextcloud base URL (https://nextcloud.example.com)"
+    )
+    parser.add_argument("username", help="Nextcloud username (admin)")
+    parser.add_argument(
+        "keyfile", help="Path to file containing password (~/nextcloud_key)"
+    )
+    args = parser.parse_args()
+
+    # Enforce HTTPS and allow some typical variants
+    url = "https://" + args.url.rstrip("/").lstrip("http://").lstrip("https://")
+    username = args.username
+
+    with open(args.keyfile) as file:
+        password = file.read()
+        file.close()
+
+    return url, username, password
+
+def raise_an_error():
+    x = 5
+    if x > 4:
+        raise ValueError(f"{x = } > 4")
+
+class ClassExample:
+    """A docstring.
+
+    Has multiple lines.
+    """
+
+    def some_method(self, x: int) -> None:
+        "Docstring."
+
+        # Print it
+        print(x)
+```
+
 # Math
 
 In this post, we will show that functions of the form

--- a/_posts/1970-01-01-formats-masterpost.md
+++ b/_posts/1970-01-01-formats-masterpost.md
@@ -148,6 +148,19 @@ class ClassExample:
         print(x)
 ```
 
+Julia example
+
+```julia
+# Main purpose of creating this was to see "special" strings (symbol, regex) in
+# action, but rouge doesn't parse them as anything special :(
+
+if 5 < 6
+    @assert match(r"\d", "hello2")
+end
+
+(string(:hello) == "hello" ? 5 : 6) |> sqrt
+```
+
 # Math
 
 In this post, we will show that functions of the form

--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -37,6 +37,7 @@ $brand-color: #008000;
 
 $grey-color: #778899;
 $green-color-light: #b7ccb7;
+$brand-color-desaturated: color.adjust($brand-color, $saturation: -50%);
 $grey-color-dark: color.adjust($grey-color, $lightness: -25%);
 
 $table-text-align: left;

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -169,7 +169,7 @@ a {
   @include subtle-underline;
 
   &:visited {
-    color: color.adjust($brand-color, $saturation: -50%);
+    color: $brand-color-desaturated;
   }
 
   &:hover {

--- a/_sass/minima/_syntax-highlighting.scss
+++ b/_sass/minima/_syntax-highlighting.scss
@@ -1,7 +1,9 @@
 /**
  * Syntax highlighting styles
  */
-$literal-color: $brand-color-desaturated;
+$literal-string-color: $brand-color-desaturated;
+$literal-number-color: #009999;
+$name-color: #445588;
 
 .highlight {
   background: $highlight-color;
@@ -9,7 +11,7 @@ $literal-color: $brand-color-desaturated;
 
   .c {
     color: $grey-color;
-    font-style: italic
+    font-style: italic;
   }
 
   // Comment
@@ -145,12 +147,13 @@ $literal-color: $brand-color-desaturated;
 
   // Keyword.Type
   .m {
-    color: #099
+    color: $literal-number-color;
+    font-weight: $monospace-font-strong-weight;
   }
 
   // Literal.Number
   .s {
-    color: $literal-color;
+    color: $literal-string-color;
   }
 
   // Literal.String
@@ -165,45 +168,45 @@ $literal-color: $brand-color-desaturated;
 
   // Name.Builtin
   .nc {
-    color: #458;
+    color: $name-color;
     font-weight: $monospace-font-strong-weight;
   }
 
   // Name.Class
   .no {
-    color: #008080
+    color: $name-color;
   }
 
   // Name.Constant
   .ni {
-    color: #800080
+    color: $name-color;
   }
 
   // Name.Entity
   .ne {
-    color: #900;
+    color: $name-color;
     font-weight: $monospace-font-strong-weight;
   }
 
   // Name.Exception
   .nf {
-    color: #900;
+    color: $name-color;
     font-weight: $monospace-font-strong-weight;
   }
 
   // Name.Function
   .nn {
-    color: #555
+    color: $name-color;
   }
 
   // Name.Namespace
   .nt {
-    color: #000080
+    color: $name-color;
   }
 
   // Name.Tag
   .nv {
-    color: #008080
+    color: $name-color;
   }
 
   // Name.Variable
@@ -218,62 +221,62 @@ $literal-color: $brand-color-desaturated;
 
   // Text.Whitespace
   .mf {
-    color: #099
+    color: $literal-number-color;
   }
 
   // Literal.Number.Float
   .mh {
-    color: #099
+    color: $literal-number-color;
   }
 
   // Literal.Number.Hex
   .mi {
-    color: #099
+    color: $literal-number-color;
   }
 
   // Literal.Number.Integer
   .mo {
-    color: #099
+    color: $literal-number-color;
   }
 
   // Literal.Number.Oct
   .sb {
-    color: $literal-color;
+    color: $literal-string-color;
   }
 
   // Literal.String.Backtick
   .sc {
-    color: $literal-color;
+    color: $literal-string-color;
   }
 
   // Literal.String.Char
   .sd {
-    color: $literal-color;
+    color: $literal-string-color;
   }
 
   // Literal.String.Doc
   .s2 {
-    color: $literal-color;
+    color: $literal-string-color;
   }
 
   // Literal.String.Double
   .se {
-    color: $literal-color;
+    color: $literal-string-color;
   }
 
   // Literal.String.Escape
   .sh {
-    color: $literal-color;
+    color: $literal-string-color;
   }
 
   // Literal.String.Heredoc
   .si {
-    color: $literal-color;
+    color: $literal-string-color;
   }
 
   // Literal.String.Interpol
   .sx {
-    color: $literal-color;
+    color: $literal-string-color;
   }
 
   // Literal.String.Other
@@ -283,7 +286,7 @@ $literal-color: $brand-color-desaturated;
 
   // Literal.String.Regex
   .s1 {
-    color: $literal-color;
+    color: $literal-string-color;
   }
 
   // Literal.String.Single

--- a/_sass/minima/_syntax-highlighting.scss
+++ b/_sass/minima/_syntax-highlighting.scss
@@ -3,7 +3,9 @@
  */
 $literal-string-color: $brand-color-desaturated;
 $literal-number-color: #009999;
+$literal-special-color: #990073;
 $name-color: #445588;
+$error-color: #a61717;
 
 .highlight {
   background: $highlight-color;
@@ -17,8 +19,7 @@ $name-color: #445588;
 
   // Error
   .err {
-    color: #a61717;
-    background-color: #e3d2d2
+    color: $error-color;
   }
 
   // Keyword
@@ -34,7 +35,7 @@ $name-color: #445588;
   // Comment.Multiline
   .cm {
     color: $grey-color;
-    font-style: italic
+    font-style: italic;
   }
 
   // Comment.Preproc
@@ -46,14 +47,14 @@ $name-color: #445588;
   // Comment.Single
   .c1 {
     color: $grey-color;
-    font-style: italic
+    font-style: italic;
   }
 
   // Comment.Special
   .cs {
     color: $grey-color;
-    font-weight: $monospace-font-strong-weight;;
-    font-style: italic
+    font-weight: $monospace-font-strong-weight;
+    font-style: italic;
   }
 
   // Generic.Deleted
@@ -75,12 +76,12 @@ $name-color: #445588;
 
   // Generic.Error
   .gr {
-    color: #a00
+    color: $error-color;
   }
 
   // Generic.Heading
   .gh {
-    color: #999
+    font-weight: $monospace-font-strong-weight;
   }
 
   // Generic.Inserted
@@ -97,12 +98,12 @@ $name-color: #445588;
 
   // Generic.Output
   .go {
-    color: #888
+    color: $grey-color;
   }
 
   // Generic.Prompt
   .gp {
-    color: #555
+    font-weight: $monospace-font-strong-weight;
   }
 
   // Generic.Strong
@@ -112,12 +113,11 @@ $name-color: #445588;
 
   // Generic.Subheading
   .gu {
-    color: #aaa
   }
 
   // Generic.Traceback
   .gt {
-    color: #a00
+    color: $error-color;
   }
 
   // Keyword.Constant
@@ -142,7 +142,7 @@ $name-color: #445588;
 
   // Keyword.Type
   .kt {
-    color: #458;
+    color: $name-color;
     font-weight: $monospace-font-strong-weight;
   }
 
@@ -159,12 +159,12 @@ $name-color: #445588;
 
   // Name.Attribute
   .na {
-    color: #008080
+    color: $name-color;
   }
 
   // Name.Builtin
   .nb {
-    color: #0086B3
+    color: $name-color;
   }
 
   // Name.Class
@@ -217,7 +217,7 @@ $name-color: #445588;
 
   // Text.Whitespace
   .w {
-    color: #bbb
+    color: #bbb;
   }
 
   // Literal.Number.Float
@@ -282,7 +282,7 @@ $name-color: #445588;
 
   // Literal.String.Regex
   .sr {
-    color: #009926
+    color: $literal-special-color;
   }
 
   // Literal.String.Single
@@ -292,31 +292,31 @@ $name-color: #445588;
 
   // Literal.String.Symbol
   .ss {
-    color: #990073
+    color: $literal-special-color;
   }
 
   // Name.Builtin.Pseudo
   .bp {
-    color: #999
+    color: $name-color;
   }
 
   // Name.Variable.Class
   .vc {
-    color: #008080
+    color: $name-color;
   }
 
   // Name.Variable.Global
   .vg {
-    color: #008080
+    color: $name-color;
   }
 
   // Name.Variable.Instance
   .vi {
-    color: #008080
+    color: $name-color;
   }
 
   // Literal.Number.Integer.Long
   .il {
-    color: #099
+    color: $literal-number-color;
   }
 }

--- a/_sass/minima/_syntax-highlighting.scss
+++ b/_sass/minima/_syntax-highlighting.scss
@@ -1,12 +1,14 @@
 /**
  * Syntax highlighting styles
  */
+$literal-color: $brand-color-desaturated;
+
 .highlight {
   background: $highlight-color;
   @extend %vertical-rhythm;
 
   .c {
-    color: #998;
+    color: $grey-color;
     font-style: italic
   }
 
@@ -28,25 +30,25 @@
 
   // Operator
   .cm {
-    color: #998;
+    color: $grey-color;
     font-style: italic
   }
 
   // Comment.Multiline
   .cp {
-    color: #999;
+    color: $grey-color;
     font-weight: $monospace-font-strong-weight;
   }
 
   // Comment.Preproc
   .c1 {
-    color: #998;
+    color: $grey-color;
     font-style: italic
   }
 
   // Comment.Single
   .cs {
-    color: #999;
+    color: $grey-color;
     font-weight: $monospace-font-strong-weight;;
     font-style: italic
   }
@@ -148,7 +150,7 @@
 
   // Literal.Number
   .s {
-    color: #d14
+    color: $literal-color;
   }
 
   // Literal.String
@@ -236,42 +238,42 @@
 
   // Literal.Number.Oct
   .sb {
-    color: #d14
+    color: $literal-color;
   }
 
   // Literal.String.Backtick
   .sc {
-    color: #d14
+    color: $literal-color;
   }
 
   // Literal.String.Char
   .sd {
-    color: #d14
+    color: $literal-color;
   }
 
   // Literal.String.Doc
   .s2 {
-    color: #d14
+    color: $literal-color;
   }
 
   // Literal.String.Double
   .se {
-    color: #d14
+    color: $literal-color;
   }
 
   // Literal.String.Escape
   .sh {
-    color: #d14
+    color: $literal-color;
   }
 
   // Literal.String.Heredoc
   .si {
-    color: #d14
+    color: $literal-color;
   }
 
   // Literal.String.Interpol
   .sx {
-    color: #d14
+    color: $literal-color;
   }
 
   // Literal.String.Other
@@ -281,7 +283,7 @@
 
   // Literal.String.Regex
   .s1 {
-    color: #d14
+    color: $literal-color;
   }
 
   // Literal.String.Single

--- a/_sass/minima/_syntax-highlighting.scss
+++ b/_sass/minima/_syntax-highlighting.scss
@@ -9,315 +9,314 @@ $name-color: #445588;
   background: $highlight-color;
   @extend %vertical-rhythm;
 
+  // Comment
   .c {
     color: $grey-color;
     font-style: italic;
   }
 
-  // Comment
+  // Error
   .err {
     color: #a61717;
     background-color: #e3d2d2
   }
 
-  // Error
+  // Keyword
   .k {
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Keyword
+  // Operator
   .o {
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Operator
+  // Comment.Multiline
   .cm {
     color: $grey-color;
     font-style: italic
   }
 
-  // Comment.Multiline
+  // Comment.Preproc
   .cp {
     color: $grey-color;
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Comment.Preproc
+  // Comment.Single
   .c1 {
     color: $grey-color;
     font-style: italic
   }
 
-  // Comment.Single
+  // Comment.Special
   .cs {
     color: $grey-color;
     font-weight: $monospace-font-strong-weight;;
     font-style: italic
   }
 
-  // Comment.Special
+  // Generic.Deleted
   .gd {
     color: #000;
     background-color: #fdd
   }
 
-  // Generic.Deleted
+  // Generic.Deleted.Specific
   .gd .x {
     color: #000;
     background-color: #faa
   }
 
-  // Generic.Deleted.Specific
+  // Generic.Emph
   .ge {
     font-style: italic
   }
 
-  // Generic.Emph
+  // Generic.Error
   .gr {
     color: #a00
   }
 
-  // Generic.Error
+  // Generic.Heading
   .gh {
     color: #999
   }
 
-  // Generic.Heading
+  // Generic.Inserted
   .gi {
     color: #000;
     background-color: #dfd
   }
 
-  // Generic.Inserted
+  // Generic.Inserted.Specific
   .gi .x {
     color: #000;
     background-color: #afa
   }
 
-  // Generic.Inserted.Specific
+  // Generic.Output
   .go {
     color: #888
   }
 
-  // Generic.Output
+  // Generic.Prompt
   .gp {
     color: #555
   }
 
-  // Generic.Prompt
+  // Generic.Strong
   .gs {
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Generic.Strong
+  // Generic.Subheading
   .gu {
     color: #aaa
   }
 
-  // Generic.Subheading
+  // Generic.Traceback
   .gt {
     color: #a00
   }
 
-  // Generic.Traceback
+  // Keyword.Constant
   .kc {
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Keyword.Constant
+  // Keyword.Declaration
   .kd {
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Keyword.Declaration
+  // Keyword.Pseudo
   .kp {
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Keyword.Pseudo
+  // Keyword.Reserved
   .kr {
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Keyword.Reserved
+  // Keyword.Type
   .kt {
     color: #458;
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Keyword.Type
+  // Literal.Number
   .m {
     color: $literal-number-color;
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Literal.Number
+  // Literal.String
   .s {
     color: $literal-string-color;
   }
 
-  // Literal.String
+  // Name.Attribute
   .na {
     color: #008080
   }
 
-  // Name.Attribute
+  // Name.Builtin
   .nb {
     color: #0086B3
   }
 
-  // Name.Builtin
+  // Name.Class
   .nc {
     color: $name-color;
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Name.Class
+  // Name.Constant
   .no {
     color: $name-color;
   }
 
-  // Name.Constant
+  // Name.Entity
   .ni {
     color: $name-color;
   }
 
-  // Name.Entity
+  // Name.Exception
   .ne {
     color: $name-color;
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Name.Exception
+  // Name.Function
   .nf {
     color: $name-color;
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Name.Function
+  // Name.Namespace
   .nn {
     color: $name-color;
   }
 
-  // Name.Namespace
+  // Name.Tag
   .nt {
     color: $name-color;
   }
 
-  // Name.Tag
+  // Name.Variable
   .nv {
     color: $name-color;
   }
 
-  // Name.Variable
+  // Operator.Word
   .ow {
     font-weight: $monospace-font-strong-weight;
   }
 
-  // Operator.Word
+  // Text.Whitespace
   .w {
     color: #bbb
   }
 
-  // Text.Whitespace
+  // Literal.Number.Float
   .mf {
     color: $literal-number-color;
   }
 
-  // Literal.Number.Float
+  // Literal.Number.Hex
   .mh {
     color: $literal-number-color;
   }
 
-  // Literal.Number.Hex
+  // Literal.Number.Integer
   .mi {
     color: $literal-number-color;
   }
 
-  // Literal.Number.Integer
+  // Literal.Number.Oct
   .mo {
     color: $literal-number-color;
   }
 
-  // Literal.Number.Oct
+  // Literal.String.Backtick
   .sb {
     color: $literal-string-color;
   }
 
-  // Literal.String.Backtick
+  // Literal.String.Char
   .sc {
     color: $literal-string-color;
   }
 
-  // Literal.String.Char
+  // Literal.String.Doc
   .sd {
     color: $literal-string-color;
   }
 
-  // Literal.String.Doc
+  // Literal.String.Double
   .s2 {
     color: $literal-string-color;
   }
 
-  // Literal.String.Double
+  // Literal.String.Escape
   .se {
     color: $literal-string-color;
   }
 
-  // Literal.String.Escape
+  // Literal.String.Heredoc
   .sh {
     color: $literal-string-color;
   }
 
-  // Literal.String.Heredoc
+  // Literal.String.Interpol
   .si {
     color: $literal-string-color;
   }
 
-  // Literal.String.Interpol
+  // Literal.String.Other
   .sx {
     color: $literal-string-color;
   }
 
-  // Literal.String.Other
+  // Literal.String.Regex
   .sr {
     color: #009926
   }
 
-  // Literal.String.Regex
+  // Literal.String.Single
   .s1 {
     color: $literal-string-color;
   }
 
-  // Literal.String.Single
+  // Literal.String.Symbol
   .ss {
     color: #990073
   }
 
-  // Literal.String.Symbol
+  // Name.Builtin.Pseudo
   .bp {
     color: #999
   }
 
-  // Name.Builtin.Pseudo
+  // Name.Variable.Class
   .vc {
     color: #008080
   }
 
-  // Name.Variable.Class
+  // Name.Variable.Global
   .vg {
     color: #008080
   }
 
-  // Name.Variable.Global
+  // Name.Variable.Instance
   .vi {
     color: #008080
   }
 
-  // Name.Variable.Instance
+  // Literal.Number.Integer.Long
   .il {
     color: #099
   }
-
-  // Literal.Number.Integer.Long
 }


### PR DESCRIPTION
Fix a few poorly organized interactions between the CSS rules for `<code>` and `<pre><code>`. Customize the syntax highlighting rules to something a little less visually noisy that incorporates the colors used elsewhere in the site. Vaguely resembles Nord.