### PR TITLE
Upgrade to Ruby v3.4

### DIFF
--- a/_conda_environment.yml
+++ b/_conda_environment.yml
@@ -6,6 +6,8 @@ dependencies:
   - curl=8.11.*
   - jq=1.7.*
   - make=4.*
-  - ruby=3.3.*
+  - ruby=3.4.*
   - shellcheck=0.10.*
   - unzip=6.0.*
+  - xz=5.6.*
+  - zlib=1.3.*


### PR DESCRIPTION
Also add xz and zlib as (explicit) conda dependencies. Required to build nokogiri (Ruby XML parsing library).