### PR TITLE
Stylesheet tweaks

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,29 +3,27 @@
     {%- assign default_paths = site.pages | map: "path" -%}
     {%- assign page_paths = site.header_pages | default: default_paths -%}
 
-    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">
-      {{- site.title | escape -}}
-    </a>
+    <div class="site-title-wrapper">
+      <div>
+        <a class="site-title" rel="author" href="{{ "/" | relative_url }}">
+          {{- site.title | escape -}}
+        </a>
+      </div>
+    </div>
 
     {%- if page_paths -%}
     <nav class="site-nav">
-      <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-      <label for="nav-trigger">
-        <span class="menu-icon">
-          <svg viewBox="0 0 18 15" width="18px" height="15px">
-            <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
-          </svg>
-        </span>
-      </label>
-      <div class="trigger">
+      <div class="page-links">
         {%- assign sorted_pages = site.pages | sort: "sort_order" -%}
         {%- for my_page in sorted_pages -%}
           {%- unless my_page.title -%}
             {%- continue -%}
           {%- endunless -%}
-        <a class="page-link" href="{{ my_page.url | relative_url }}">
-          {{- my_page.title | escape -}}
-        </a>
+        <div>
+          <a class="page-link" href="{{ my_page.url | relative_url }}">
+            {{- my_page.title | escape -}}
+          </a>
+        </div>
         {%- endfor -%}
       </div>
     </nav>

--- a/_posts/1970-01-01-formats-masterpost.md
+++ b/_posts/1970-01-01-formats-masterpost.md
@@ -12,6 +12,8 @@ Here is a post with all kinds of crazy formatting so that I can test out my CSS.
 
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquam ipsa ducimus laudantium, ab numquam optio cumque perspiciatis voluptatum quis accusantium, atque excepturi, laboriosam similique! Laboriosam sed dignissimos quasi non animi!
 
+Make sure the keyboard element <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>Delete</kbd> doesn’t mess up the spacing.
+
 ## Heading bravo
 
 Lorem ipsum dolor sit amet consectetur adipisicing elit. Aliquam ipsa ducimus laudantium, ab numquam optio cumque perspiciatis voluptatum quis accusantium, atque excepturi, laboriosam similique! Laboriosam sed dignissimos quasi non animi!

--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -32,7 +32,8 @@ $background-color-light: color.adjust($background-color, $lightness: 2%);
 // Plain brand color is used for links (there are plenty of them). Desaturated
 // variant is more legible, for visited links and strings in syntax
 // highlighting. Light variant is for secondary design elements: horizontal
-// rules, vertical rule left of blockquotes, table header background.
+// rules, vertical rule left of blockquotes, table header background. Should
+// mainly be referenced via border-heavy to ensure consistent width.
 $brand-color: #008000;
 $brand-color-desaturated: color.adjust($brand-color, $saturation: -50%);
 $brand-color-light: #b7ccb7;

--- a/_sass/minima.scss
+++ b/_sass/minima.scss
@@ -36,6 +36,7 @@ $background-color-light: color.adjust($background-color, $lightness: 2%);
 $brand-color: #008000;
 $brand-color-desaturated: color.adjust($brand-color, $saturation: -50%);
 $brand-color-light: #b7ccb7;
+$border-heavy: 2px solid $brand-color-light;
 
 // Width of the content area
 $content-width: 800px;

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -152,14 +152,13 @@ li {
 /**
  * Headings
  */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  font-weight: $base-font-weight;
-}
+// h1,
+// h2,
+// h3,
+// h4,
+// h5,
+// h6 {
+// }
 
 
 
@@ -219,7 +218,7 @@ a {
  */
 blockquote {
   color: $text-color-light;
-  border-left: 2px solid $brand-color-light;
+  border-left: $border-heavy;
   padding-left: math.div($spacing-unit, 3);
 
   > :last-child {
@@ -242,7 +241,7 @@ code {
 // Code blocks
 pre:has(code) {
   font-size: $monospace-font-size;
-  border: 2px solid $brand-color-light;
+  border: $border-heavy;
   padding: 8px 12px;
   overflow-x: auto;
   background: $background-color-light;
@@ -341,7 +340,7 @@ table {
 
 // Add a separator at top of footnotes
 div.footnotes {
-  border-top: 2px solid $brand-color-light;
+  border-top: $border-heavy;
   padding-top: math.div($spacing-unit, 2);
 }
 

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -271,8 +271,7 @@ kbd {
  * Wrapper
  */
 .wrapper {
-  max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit} * 2));
-  max-width: calc(#{$content-width} - (#{$spacing-unit} * 2));
+  max-width: $content-width - $spacing-unit * 2;
   margin-right: auto;
   margin-left: auto;
   padding-right: $spacing-unit;

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -219,7 +219,7 @@ a {
  */
 blockquote {
   color: $text-color-light;
-  border-left: 3px solid $brand-color-light;
+  border-left: 2px solid $brand-color-light;
   padding-left: math.div($spacing-unit, 3);
 
   > :last-child {
@@ -242,8 +242,7 @@ code {
 // Code blocks
 pre:has(code) {
   font-size: $monospace-font-size;
-  border: 1px solid $brand-color-light;
-  border-radius: 3px;
+  border: 2px solid $brand-color-light;
   padding: 8px 12px;
   overflow-x: auto;
   background: $background-color-light;
@@ -342,7 +341,7 @@ table {
 
 // Add a separator at top of footnotes
 div.footnotes {
-  border-top: 1px solid $brand-color-light;
+  border-top: 2px solid $brand-color-light;
   padding-top: math.div($spacing-unit, 2);
 }
 

--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -244,6 +244,7 @@ pre:has(code) {
   border: $border-heavy;
   padding: 8px 12px;
   overflow-x: auto;
+  resize: horizontal;
   background: $background-color-light;
 
   code {
@@ -276,25 +277,6 @@ kbd {
   margin-left: auto;
   padding-right: $spacing-unit;
   padding-left: $spacing-unit;
-  @extend %clearfix;
-
-  @include media-query($on-laptop) {
-    max-width: -webkit-calc(#{$content-width} - (#{$spacing-unit}));
-    max-width: calc(#{$content-width} - (#{$spacing-unit}));
-    padding-right: math.div($spacing-unit, 2);
-    padding-left: math.div($spacing-unit, 2);
-  }
-}
-
-
-
-/**
- * Clearfix
- */
-%clearfix:after {
-  content: "";
-  display: table;
-  clear: both;
 }
 
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -23,9 +23,8 @@
 }
 
 .site-title {
-  font-size: 1.625rem;
-  font-weight: lighter;
-  letter-spacing: -0.5px;
+  font-weight: $base-font-weight-strong;
+  font-size: 1.2rem;
 
   &,
   &:visited {

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -7,21 +7,25 @@
  */
 .site-header {
   background: $background-color-light;
-  border-top: 0;
   border-bottom: $border-heavy;
-  min-height: $spacing-unit * 1.865;
+  border-top: 0;
 
-  // Positioning context for the mobile navigation icon
-  position: relative;
+  .wrapper {
+    padding-top: math.div($spacing-unit, 2);
+    padding-bottom: math.div($spacing-unit, 2);
+
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: $spacing-unit;
+    align-items: baseline;
+  }
 }
 
 .site-title {
   font-size: 1.625rem;
   font-weight: 400;
-  line-height: $base-line-height * $base-font-size * 2.25;
   letter-spacing: -0.5px;
-  margin-bottom: 0;
-  float: left;
 
   &,
   &:visited {
@@ -30,77 +34,13 @@
 }
 
 .site-nav {
-  float: right;
-  line-height: $base-line-height * $base-font-size * 2.25;
-
-  .nav-trigger {
-    display: none;
-  }
-
-  .menu-icon {
-    display: none;
-  }
-
-  .page-link {
-    color: $text-color;
-    line-height: $base-line-height;
-
-    // Gaps between nav items, but not on the last one
-    &:not(:last-child) {
-      margin-right: 20px;
-    }
-  }
-
-  @include media-query($on-palm) {
-    position: absolute;
-    top: 9px;
-    right: math.div($spacing-unit, 2);
-    border: 1px solid $text-color-light;
-    border-radius: 3px;
-    text-align: right;
-
-    label[for="nav-trigger"] {
-      display: block;
-      float: right;
-      width: 36px;
-      height: 36px;
-      z-index: 2;
-      cursor: pointer;
-    }
-
-    .menu-icon {
-      display: block;
-      float: right;
-      width: 36px;
-      height: 26px;
-      line-height: 0;
-      padding-top: 10px;
-      text-align: center;
-
-      >svg {
-        fill: $text-color-light;
-      }
-    }
-
-    input~.trigger {
-      clear: both;
-      display: none;
-    }
-
-    input:checked~.trigger {
-      display: block;
-      padding-bottom: 5px;
-    }
+  .page-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: math.div($spacing-unit, 2);
 
     .page-link {
-      display: block;
-      padding: 5px 10px;
-
-      &:not(:last-child) {
-        margin-right: 0;
-      }
-
-      margin-left: 20px;
+      color: $text-color;
     }
   }
 }
@@ -134,7 +74,6 @@
   grid-template-columns: auto auto 1fr;
   justify-content: space-between;
   gap: 0 (2 * $spacing-unit);
-  @extend %clearfix;
 
   @include media-query($on-laptop) {
     // Collapse to two columns

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -6,8 +6,9 @@
  * Site header
  */
 .site-header {
+  background: $background-color-light;
   border-top: 0;
-  border-bottom: 1px solid $brand-color-light;
+  border-bottom: 2px solid $brand-color-light;
   min-height: $spacing-unit * 1.865;
 
   // Positioning context for the mobile navigation icon
@@ -55,8 +56,8 @@
     top: 9px;
     right: math.div($spacing-unit, 2);
     background-color: $background-color;
-    border: 1px solid $brand-color-light;
-    border-radius: 5px;
+    border: 1px solid $text-color-light;
+    border-radius: 3px;
     text-align: right;
 
     label[for="nav-trigger"] {
@@ -111,7 +112,8 @@
  * Site footer
  */
 .site-footer {
-  border-top: 1px solid $brand-color-light;
+  background: $background-color-light;
+  border-top: 2px solid $brand-color-light;
   padding: $spacing-unit 0;
 }
 

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -17,14 +17,14 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    gap: $spacing-unit;
+    gap: 0 $spacing-unit;
     align-items: baseline;
   }
 }
 
 .site-title {
   font-size: 1.625rem;
-  font-weight: 400;
+  font-weight: lighter;
   letter-spacing: -0.5px;
 
   &,
@@ -37,7 +37,7 @@
   .page-links {
     display: flex;
     flex-wrap: wrap;
-    gap: math.div($spacing-unit, 2);
+    gap: 0 math.div($spacing-unit, 2);
 
     .page-link {
       color: $text-color;

--- a/_sass/minima/_layout.scss
+++ b/_sass/minima/_layout.scss
@@ -8,7 +8,7 @@
 .site-header {
   background: $background-color-light;
   border-top: 0;
-  border-bottom: 2px solid $brand-color-light;
+  border-bottom: $border-heavy;
   min-height: $spacing-unit * 1.865;
 
   // Positioning context for the mobile navigation icon
@@ -55,7 +55,6 @@
     position: absolute;
     top: 9px;
     right: math.div($spacing-unit, 2);
-    background-color: $background-color;
     border: 1px solid $text-color-light;
     border-radius: 3px;
     text-align: right;
@@ -113,7 +112,7 @@
  */
 .site-footer {
   background: $background-color-light;
-  border-top: 2px solid $brand-color-light;
+  border-top: $border-heavy;
   padding: $spacing-unit 0;
 }
 
@@ -214,14 +213,10 @@
 
   h1 {
     font-size: 1.5rem;
-    font-weight: $base-font-weight;
-    color: $text-color-light;
   }
 
   h2 {
     font-size: 1.2rem;
-    font-weight: $base-font-weight;
-    color: $text-color-light;
     margin-bottom: math.div($spacing-unit, 4);
   }
 


### PR DESCRIPTION
Remove many stylesheet rules and condense others in pursuit of a more coherent look.

Most noticeable change is the use of bold face in headings, which removes the need to differentiate them using a different color (becomes three colors when a heading is also a link, as on the index page).

Old stylesheet also mixed 1px borders with 3px borders in the light theme color; now these are all 2px, which makes the whole thing blockier overall but perhaps more consistent.

Also removed the default Jekyll "hamburger menu" on mobile and replaced it with a simple list of pages, since there aren't many.