### PR TITLE
Remove redundant plugin specifications

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,13 +15,6 @@ rss: "via RSS"
 excerpt_separator: "<!--more-->"
 future: false  # Don't publish posts dated in future
 show_excerpts: true  # on homepage
-
-gems: [jekyll-paginate-v2]
-
-plugins:
-  - "jekyll-redirect-from"
-  - "jekyll-paginate-v2"
-
 theme: "minima"
 
 # Select markdown processor. kramdown is the default


### PR DESCRIPTION
Remove plugins that were defined in `_config.yml` (in both the `plugins:` and `gems:` blocks). They are already requested in `Gemfile` in the `:jekyll_plugins` group, which is sufficient according to the Jekyll docs here:

https://jekyllrb.com/docs/plugins/installation/