### PR TITLE
Use normal whitespace instead of `&ZeroWidthSpace;`

### DIFF
--- a/browse.html
+++ b/browse.html
@@ -52,7 +52,7 @@ permalink: /browse/
       <a href="{{ post.url | relative_url }}">
         {{- post.title | escape -}}
       </a>
-      &ZeroWidthSpace;
+      {%- comment -%} Intentional whitespace {%- endcomment %}
       <span class="post-meta">
         (<time datetime="{{ post.date | date_to_xmlschema }}">
         {{- post.date | date: date_format -}}

--- a/feed.xsl
+++ b/feed.xsl
@@ -76,7 +76,9 @@
           </xsl:attribute>
           <xsl:value-of select="atom:title" />
         </a>
-        &#8203; <!-- == &ZeroWidthSpace; -->
+
+        {%- comment -%} Intentional whitespace {%- endcomment %}
+
         <span class="post-meta">
           <time>
             <xsl:attribute name="datetime">

--- a/index.html
+++ b/index.html
@@ -61,4 +61,3 @@ pagination:
     {%- endif %}
   {%- endif %}
 </div>
-


### PR DESCRIPTION
To force space between inline post titles and dates in the styled Atom feed and `/browse/` page. The attempt to be clever with `&ZeroWidthSpace;` doesn't work in Chrome.